### PR TITLE
Add authselect parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 05 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.2.4
+- Added authselect parameter
+
 * Tue May 16 2023 Mike Riddle <mike@sicura.us> - 0.2.3
 - Added support for authselect
 - Added the tidy option to give the users an option to not purge

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class dconf (
   Boolean                       $use_user_settings_defaults  = $use_user_profile_defaults,
   String[1]                     $user_settings_defaults_name = $user_profile_defaults_name,
   Boolean                       $tidy                        = true,
+  Boolean                       $authselect                  = simplib::lookup('simp_options::authselect', { 'default_value' => false }),
 ) {
   simplib::assert_metadata($module_name)
 
@@ -69,7 +70,7 @@ class dconf (
   }
 
   # If using authselect, the following files need to managed or there will be conflicts
-  if $simp_options::authselect {
+  if $authselect {
     file { '/etc/dconf/db/distro.d/20-authselect': }
     file { '/etc/dconf/db/distro.d/locks/20-authselect': }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-dconf",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": "SIMP Team",
   "summary": "Provides an interface to system DConf configuration",
   "license": "Apache-2.0",


### PR DESCRIPTION
Update module to follow paradigm of SIMP module interacting with `simp_options::` variables through class parameters.  

Among other things, this allows spec tests in modules that require dconf to run without adding mocks for `simp_options::`